### PR TITLE
first round of bug fixes

### DIFF
--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -1949,7 +1949,7 @@
 
 			<var name="tend_nc" name_in_code="nc" array_group="number" units="nb m^{-3} s^{-1}" 
                              description="Tendency of cloud number concentration multiplied by dry air density divided by d(zeta)/dz"
-                             packages="mp_thompson_in;mp_nssl12m_in"/>
+                             packages="mp_thompson_in;mp_nssl2m_in"/>
 			
                         <var name="tend_nr" name_in_code="nr" array_group="number" units="nb m^{-3} s^{-1}" 
                              description="Tendency of rain number concentration multiplied by dry air density divided by d(zeta)/dz"
@@ -2476,7 +2476,7 @@
 
 		<var name="refl10cm" type="real" dimensions="nVertLevels nCells Time" units="dBZ"
                      description="10 cm radar reflectivity"
-                     packages="mp_thompson_in;mp_wsm6_in;mp_nssl12m_in"/>
+                     packages="mp_thompson_in;mp_wsm6_in;mp_nssl2m_in"/>
 
                 <var name="refl10cm_max" type="real" dimensions="nCells Time" units="dBZ"
                      description="10 cm maximum radar reflectivity"
@@ -2645,7 +2645,7 @@
 
                 <var name="delta" type="real" dimensions="nCells Time" units="m"
                      description="entrainment layer depth from PBL scheme"
-                     packages="bl_mynn_in;bl_ysu_in;bl_myj_in"/>
+                     packages="bl_ysu_in;bl_myj_in"/>
 
                 <var name="wstar" type="real" dimensions="nCells Time" units="m s^{-1}"
                      description="mixed velocity scale from PBL scheme"
@@ -2665,14 +2665,6 @@
 
 
                 <!-- YSU PBL SCHEME: -->
-                <var name="delta" type="real" dimensions="nCells Time" units="m"
-                     description="entrainment layer depth from PBL scheme"
-                     packages="bl_ysu_in"/>
-
-                <var name="wstar" type="real" dimensions="nCells Time" units="m s^{-1}"
-                     description="mixed velocity scale from PBL scheme"
-                     packages="bl_ysu_in"/>
-
                 <var name="exch_h" type="real" dimensions="nVertLevels nCells Time" units="m^{2} s^{-1}"
                      description="exchange coefficient"
                      packages="bl_ysu_in"/>
@@ -3550,10 +3542,6 @@
 		<var name="rqiblten" type="real" dimensions="nVertLevels nCells Time" units="kg kg^{-1} s^{-1}"
                      description="tendency of cloud ice mixing ratio due to pbl processes"
                      packages="bl_mynn_in;bl_ysu_in;bl_myj_in"/>
-
-                <var name="rqsblten" type="real" dimensions="nVertLevels nCells Time" units="kg kg^{-1} s^{-1}"
-                     description="tendency of snow mixing ratio due to pbl processes"
-                     packages="bl_mynn_in"/>
 
                 <var name="rqsblten" type="real" dimensions="nVertLevels nCells Time" units="kg kg^{-1} s^{-1}"
                      description="tendency of snow mixing ratio due to pbl processes"

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_pbl.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_pbl.F
@@ -634,9 +634,6 @@
 !local pointers for MYJ scheme:
  real(kind=RKIND),dimension(:),pointer   :: thz0,qz0,uz0,vz0,akhs,akms,ct,mixht,qsfc,ust,znt
 
-!local pointers for MYJ scheme:
- real(kind=RKIND),dimension(:),pointer   :: thz0,qz0,uz0,vz0,akhs,akms,ct,mixht,qsfc,ust,znt
-
 !-----------------------------------------------------------------------------------------------------------------
 
  call mpas_pool_get_config(configs,'config_pbl_scheme',pbl_scheme)
@@ -1056,95 +1053,6 @@
        call mpas_timer_stop('bl_mynn')
 !      call mpas_log_write('--- exit subroutine mynn_bl_driver:')
 !      call mpas_log_write(' ')
-
-    case("bl_myj")
-       if (initflag==1) then
-          do i = its,ite
-          do k = kts,kte
-          do j = jts,jte
-             tkepbl_p(i,k,j) = epsq2
-          enddo
-          enddo
-          enddo
-       endif
-       call mpas_timer_start('MYJ_pbl')
-       call mpas_log_write('dt_pbl = $r',realArgs=(/dt_pbl/))
-!       call mpas_log_write("BEFORE MYJPBL")
-! call mpas_dmpar_min_real(domain % dminfo, minval(ht_p), scalar_min)
-! call mpas_dmpar_min_real(domain % dminfo, maxval(ht_p), scalar_max)
-!call mpas_log_write('MIN/MAX ht_p = $r, $r', realArgs=(/scalar_min,scalar_max/)
-!
-! call mpas_dmpar_min_real(domain % dminfo, minval(qsfc_p), scalar_min)
-! call mpas_dmpar_min_real(domain % dminfo, maxval(qsfc_p), scalar_max)
-!call mpas_log_write('MIN/MAX qsfc_p = $r, $r', realArgs=(/scalar_min,scalar_max/)
-!
-! call mpas_dmpar_min_real(domain % dminfo, minval(thz0_p), scalar_min)
-! call mpas_dmpar_min_real(domain % dminfo, maxval(thz0_p), scalar_max)
-!call mpas_log_write('MIN/MAX thz0_p = $r, $r',realArgs=(/scalar_min,scalar_max/)
-!
-! call mpas_dmpar_min_real(domain % dminfo, minval(qz0_p), scalar_min)
-! call mpas_dmpar_min_real(domain % dminfo, maxval(qz0_p), scalar_max)
-!call mpas_log_write('MIN/MAX qz0_p = $r, $r',realArgs=(/scalar_min,scalar_max/)
-!
-! call mpas_dmpar_min_real(domain % dminfo, minval(uz0_p), scalar_min)
-! call mpas_dmpar_min_real(domain % dminfo, maxval(uz0_p), scalar_max)
-!call mpas_log_write('MIN/MAX uz0_p = $r, $r', realArgs=(/scalar_min,scalar_max/)
-!
-! call mpas_dmpar_min_real(domain % dminfo, minval(vz0_p), scalar_min)
-! call mpas_dmpar_min_real(domain % dminfo, maxval(vz0_p), scalar_max)
-!call mpas_log_write('MIN/MAX vz0_p = $r, $r',realArgs=(/scalar_min,scalar_max/)
-!
-! call mpas_dmpar_min_real(domain % dminfo, minval(tkepbl_p), scalar_min)
-! call mpas_dmpar_min_real(domain % dminfo, maxval(tkepbl_p), scalar_max)
-!call mpas_log_write('MIN/MAX tkepbl_p = $r, $r',realArgs=(/scalar_min,scalar_max/)
-!
-! call mpas_dmpar_min_real(domain % dminfo, minval(kzh_p), scalar_min)
-! call mpas_dmpar_min_real(domain % dminfo, maxval(kzh_p), scalar_max)
-!call mpas_log_write('MIN/MAX kzh_p = $r, $r',realArgs=(/scalar_min,scalar_max/)
-!
-! call mpas_dmpar_min_real(domain % dminfo, minval(ust_p), scalar_min)
-! call mpas_dmpar_min_real(domain % dminfo, maxval(ust_p), scalar_max)
-!call mpas_log_write('MIN/MAX ust_p = $r, $r', realArgs=(/scalar_min,scalar_max/)
-!
-! call mpas_dmpar_min_real(domain % dminfo, minval(znt_p), scalar_min)
-! call mpas_dmpar_min_real(domain % dminfo, maxval(znt_p), scalar_max)
-!call mpas_log_write('MIN/MAX znt_p = $r, $r',realArgs=(/scalar_min,scalar_max/)
-!
-! call mpas_dmpar_min_real(domain % dminfo, minval(ct_p), scalar_min)
-! call mpas_dmpar_min_real(domain % dminfo, maxval(ct_p), scalar_max)
-!call mpas_log_write('MIN/MAX ct_p = $r, $r',realArgs=(/scalar_min,scalar_max/)
-!
-! call mpas_dmpar_min_real(domain % dminfo, minval(akhs_p), scalar_min)
-! call mpas_dmpar_min_real(domain % dminfo, maxval(akhs_p), scalar_max)
-!call mpas_log_write('MIN/MAX akhs_p = $r, $r', realArgs=(/scalar_min,scalar_max/)
-!
-! call mpas_dmpar_min_real(domain % dminfo, minval(akms_p), scalar_min)
-! call mpas_dmpar_min_real(domain % dminfo, maxval(akms_p), scalar_max)
-!call mpas_log_write('MIN/MAX akms_p = $r, $r', realArgs=(/scalar_min,scalar_max/)
-
-       call myjpbl ( &
-                dt       = dt_pbl    , stepbl   = 1          , ht       = ht_p       , &
-                pmid     = pres_hyd_p, pint     = pres2_hyd_p, th       = th_p       , &
-                t        = t_p       , exner    = pi_p       , qv       = qv_p       , &
-                qcw      = qc_p      , qci      = qi_p       , qcs      = qs_p       , &
-                qcr      = qr_p      , qcg      = qg_p       , u        = u_p        , &
-                v        = v_p       , rho      = rho_p      , tsk      = tsk_p      , &
-                qsfc     = qsfc_p    , chklowq   = chlowq_p   , thz0     = thz0_p     , &
-                qz0      = qz0_p     , uz0      = uz0_p      , vz0      = vz0_p      , &
-                lowlyr   = lowlyr_p  , xland    = xland_p    , sice     = xice_p     , &
-                snow     = snow_p    , tke_myj  = tkepbl_p   , exch_h   = kzh_p      , &
-                ustar    = ust_p     , znt      = znt_p      , el_myj   = elpbl_p    , &
-                pblh     = hpbl_p    , kpbl     = kpbl_p     , ct       = ct_p       , &
-                akhs     = akhs_p    , akms     = akms_p     , elflx    = lh_p       , &
-                mixht    = mixht_p   , rublten  = rublten_p  , rvblten  = rvblten_p  , &
-                rthblten = rthblten_p, rqvblten = rqvblten_p , rqcblten = rqcblten_p , &
-                rqiblten = rqiblten_p, dz       = dz_p       ,                         &
-                ids = ids , ide = ide , jds = jds , jde = jde , kds = kds , kde = kde, &
-                ims = ims , ime = ime , jms = jms , jme = jme , kms = kms , kme = kme, &
-                its = its , ite = ite , jts = jts , jte = jte , kts = kts , kte = kte  &
-                            )
-       call mpas_timer_stop('MYJ_pbl')
-         
 
     case("bl_myj")
        if (initflag==1) then

--- a/src/core_atmosphere/physics/mpas_atmphys_interface.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_interface.F
@@ -713,7 +713,7 @@
  character(len=StrKIND),pointer:: nssl_moments
  integer,pointer:: index_qv,index_qc,index_qr,index_qi,index_qs,index_qg,index_qh
  integer,pointer:: index_zrw,index_zgw,index_zhw
- integer,pointer:: index_ni,index_nc,index_nr,index_nc,index_ns,index_ng,index_nh,index_nccn
+ integer,pointer:: index_ni,index_nc,index_nr,index_ns,index_ng,index_nh,index_nccn
  integer,pointer:: index_volg,index_volh,index_nwfa,index_nifa
  real(kind=RKIND),dimension(:),pointer    :: surface_pressure,tend_sfc_pressure
  real(kind=RKIND),dimension(:,:),pointer  :: zgrid
@@ -722,7 +722,7 @@
  real(kind=RKIND),dimension(:,:),pointer  :: rt_diabatic_tend
  real(kind=RKIND),dimension(:,:),pointer  :: dtheta_dt_mp
  real(kind=RKIND),dimension(:,:),pointer  :: qv,qc,qr,qi,qs,qg,qh
- real(kind=RKIND),dimension(:,:),pointer  :: ni,nr,nc,ns,ng,nh,nccn,nc,nwfa,nifa
+ real(kind=RKIND),dimension(:,:),pointer  :: ni,nr,nc,ns,ng,nh,nccn,nwfa,nifa
  real(kind=RKIND),dimension(:,:),pointer  :: volg,volh,zrw,zgw,zhw
  real(kind=RKIND),dimension(:,:),pointer  :: rainprod,evapprod,refl10cm
  real(kind=RKIND),dimension(:,:),pointer  :: re_cloud,re_ice,re_snow

--- a/src/core_atmosphere/physics/mpas_atmphys_vars.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_vars.F
@@ -209,8 +209,7 @@
     ni_p,             &!
     nr_p,             &!
     ns_p, ng_p, nh_p, nccn_p, &
-    volg_p, volh_p,   &
-  &!
+    volg_p, volh_p,   &!
     nwfa_p,           &!
     nifa_p,             zrw_p, zgw_p, zhw_p
 


### PR DESCRIPTION
This took care of the first 10 or so bug fixes. Now, I'm at this stage:

rm -f mpas_atm_core_interface.o mpas_atm_core_interface.mod
mpiifort -D_MPI -DCORE_ATMOSPHERE -DMPAS_NAMELIST_SUFFIX=atmosphere -DMPAS_EXE_NAME=atmosphere_model -DMPAS_DEBUG -DSINGLE_PRECISION -DMPAS_NATIVE_TIMERS -DMPAS_GIT_VERSION=unknown -DMPAS_BUILD_TARGET=intel-mpi -DMPAS_SMIOL_SUPPORT -DMPAS_USE_MPI_F08 -DDO_PHYSICS -g -convert big_endian -free -CU -CB -check all -fpe0 -traceback -c mpas_atm_core_interface.F -I/apps/netcdf/4.9.2/gnu_13.2.0_seq/include -I/apps/pnetcdf/1.12.3/intel_2023.2.0-impi//include -I/mnt/lfs5/BMC/rtwbl/olson/MPAS-Model_NSSL/src/external/SMIOL -I/apps/netcdf/4.9.2/gnu_13.2.0_seq/include -I/apps/pnetcdf/1.12.3/intel_2023.2.0-impi//include -I./inc -I../framework -I../operators -I./physics -I./dynamics -I./diagnostics -I./physics/physics_wrf -I./physics/physics_mmm -I../external/esmf_time_f90
./inc/block_dimension_routines.inc(38): error #6418: This name has already been assigned a data type.   [NLCAT]
      integer, pointer :: nlcat
--------------------------^
./inc/block_dimension_routines.inc(38): error #6227: This name has already been assigned the POINTER attribute.   [NLCAT]
      integer, pointer :: nlcat
--------------------------^
./inc/block_dimension_routines.inc(39): error #6418: This name has already been assigned a data type.   [NSCAT]
      integer, pointer :: nscat
--------------------------^
./inc/block_dimension_routines.inc(39): error #6227: This name has already been assigned the POINTER attribute.   [NSCAT]
      integer, pointer :: nscat
--------------------------^
./inc/block_dimension_routines.inc(292): error #6106: Not a valid argument for ASSOCIATE or SELECT TYPE.   [ASSOCIATED]
